### PR TITLE
Moving from SQLite to DuckDB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ uvicorn>=0.27.1
 pydantic>=1.10.13
 fastapi>=0.110.0
 pandas>=1.5.3
+duckdb>=0.8.1


### PR DESCRIPTION
ChromaDB seems to work better on Streamlit Cloud with DuckDB rather than SQLite. To address this, we just added one more requirement to the requirements file.